### PR TITLE
feat: add Request Log tab for real-time request monitoring

### DIFF
--- a/.changeset/request-log-feature.md
+++ b/.changeset/request-log-feature.md
@@ -1,0 +1,17 @@
+---
+"@custardcream/msw-devtools": minor
+---
+
+feat: add Request Log tab for real-time request/response monitoring
+
+- Add 4th "Log" tab with real-time request/response logging
+- Capture matched and unmatched MSW requests via worker events
+- Show timestamp, method, status, URL, and response duration per entry
+- Expandable accordion for request/response body inspection
+- "Add Mock for this URL" shortcut on unmatched requests
+- Recording toggle, clear button, and All/Matched/Unmatched filter
+- Unread badge on Log tab when new requests arrive on other tabs
+- Early buffer captures requests before React tree mounts
+- Filter out static assets (.js, .css, etc.) and dev server requests
+- FIFO cap at 200 entries, memory only (no localStorage)
+- Full i18n support (EN/KO)

--- a/packages/msw-devtools/src/DevTools.tsx
+++ b/packages/msw-devtools/src/DevTools.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from "react-i18next"
 import { FaXmark } from "react-icons/fa6"
 
 import { FloatingButtonSettingsProvider } from "~/components/contexts/floating-button"
+import { RequestLogProvider } from "~/components/contexts/request-log"
 import { FloatingButton } from "~/components/FloatingButton"
 import { Layout } from "~/components/Layout"
 import { TabBar, TabProvider } from "~/components/tabs/TabBar"
@@ -38,17 +39,19 @@ const DevTools = ({ initialOpen = true }: { initialOpen?: boolean }) => {
         isOpened={isOpened}
       >
         <TabProvider>
-          <TabBar>
-            <button
-              type='button'
-              className='rounded p-1 text-slate-400 transition-colors hover:bg-slate-100 hover:text-slate-600'
-              onClick={close}
-              title={t("closeButton.title")}
-            >
-              <FaXmark size={14} />
-            </button>
-          </TabBar>
-          <TabBody />
+          <RequestLogProvider>
+            <TabBar>
+              <button
+                type='button'
+                className='rounded p-1 text-slate-400 transition-colors hover:bg-slate-100 hover:text-slate-600'
+                onClick={close}
+                title={t("closeButton.title")}
+              >
+                <FaXmark size={14} />
+              </button>
+            </TabBar>
+            <TabBody />
+          </RequestLogProvider>
         </TabProvider>
       </Layout>
     </FloatingButtonSettingsProvider>

--- a/packages/msw-devtools/src/components/contexts/request-log.tsx
+++ b/packages/msw-devtools/src/components/contexts/request-log.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react"
 
 import { Tab } from "~/constants"
-import { getWorkerWithoutThrow } from "~/lib/msw/worker"
+import { drainEarlyBuffer, getWorkerWithoutThrow } from "~/lib/msw/worker"
 
 import { useTab } from "../tabs/TabBar/context"
 
@@ -32,21 +32,38 @@ export type RequestLogContextType = {
 }
 
 // ---------------------------------------------------------------------------
-// 상수
+// Constants
 // ---------------------------------------------------------------------------
 
-/** FIFO 최대 로그 수 */
+/** Max log entries (FIFO) */
 const MAX_LOG_SIZE = 200
 
-// Tab.Log 상수 참조
+/** Skip static assets, HMR, and browser-internal requests */
+const IGNORED_EXTENSIONS =
+  /\.(js|mjs|cjs|ts|tsx|jsx|css|less|scss|map|svg|png|jpg|jpeg|gif|webp|ico|woff2?|ttf|eot|json)(\?|$)/i
+const IGNORED_PATHS = /\/@(vite|fs|id)\//
+
+function shouldCaptureRequest(url: string): boolean {
+  try {
+    const { pathname } = new URL(url)
+    if (IGNORED_EXTENSIONS.test(pathname)) return false
+    if (IGNORED_PATHS.test(pathname)) return false
+    return true
+  } catch {
+    return true
+  }
+}
+
+// Tab.Log constant reference
 const TAB_LOG = Tab.Log
 
 // ---------------------------------------------------------------------------
 // Context + Hook
 // ---------------------------------------------------------------------------
 
-const RequestLogContext =
-  React.createContext<RequestLogContextType | null>(null)
+const RequestLogContext = React.createContext<RequestLogContextType | null>(
+  null
+)
 
 export const useRequestLog = () => {
   const context = React.useContext(RequestLogContext)
@@ -59,7 +76,7 @@ export const useRequestLog = () => {
 }
 
 // ---------------------------------------------------------------------------
-// Helper: request body를 안전하게 파싱
+// Helper: safely parse request/response body
 // ---------------------------------------------------------------------------
 
 async function safeParseBody(
@@ -88,35 +105,40 @@ export const RequestLogProvider = ({ children }: React.PropsWithChildren) => {
   const [isRecording, setIsRecording] = useState(true)
   const [unreadCount, setUnreadCount] = useState(0)
 
-  // useRef로 안정 참조 — 이벤트 핸들러 내에서 최신 값 접근
+  // Stable refs for accessing latest values inside event handlers
   const isRecordingRef = useRef(isRecording)
   isRecordingRef.current = isRecording
 
-  // 현재 탭 확인 (Log 탭이 아니면 unreadCount 증가)
+  // Track current tab (increment unreadCount when not on Log tab)
   const { tab } = useTab()
   const tabRef = useRef(tab)
   tabRef.current = tab
 
-  // request:start 시각 기록용 Map
+  // Map for tracking request:start timestamps
   const startTimesRef = useRef(new Map<string, number>())
 
-  // ---- FIFO append 헬퍼 ----
+  // ---- FIFO append helper ----
   const appendLog = useCallback((entry: RequestLogEntry) => {
     setLogs((prev) => {
       const next = [...prev, entry]
       return next.length > MAX_LOG_SIZE ? next.slice(-MAX_LOG_SIZE) : next
     })
-    // 현재 탭이 Log가 아니면 unread 증가
+    // Increment unread when not on Log tab
     if (tabRef.current !== TAB_LOG) {
       setUnreadCount((c) => c + 1)
     }
   }, [])
 
-  // ---- 로그 항목 업데이트 헬퍼 (response:mocked / response:bypass) ----
+  // ---- Log entry update helper (response:mocked / async body parsing) ----
   const updateLog = useCallback(
     (
       requestId: string,
-      patch: Partial<Pick<RequestLogEntry, "status" | "duration" | "responseBody">>
+      patch: Partial<
+        Pick<
+          RequestLogEntry,
+          "status" | "duration" | "responseBody" | "requestBody"
+        >
+      >
     ) => {
       setLogs((prev) =>
         prev.map((entry) =>
@@ -127,7 +149,71 @@ export const RequestLogProvider = ({ children }: React.PropsWithChildren) => {
     []
   )
 
-  // ---- MSW 이벤트 구독 ----
+  // ---- Drain early buffer on mount (captures requests before Provider mounted) ----
+  useEffect(() => {
+    const buffer = drainEarlyBuffer()
+    if (buffer.length === 0) return
+
+    const startTimes = new Map<string, number>()
+    for (const event of buffer) {
+      switch (event.type) {
+        case "start":
+          startTimes.set(event.requestId, event.timestamp)
+          break
+        case "match":
+          if (!shouldCaptureRequest(event.request.url)) break
+          appendLog({
+            id: event.requestId,
+            timestamp: event.timestamp,
+            method: event.request.method,
+            url: event.request.url,
+            matched: true,
+            duration: startTimes.get(event.requestId)
+              ? performance.now() - startTimes.get(event.requestId)!
+              : undefined
+          })
+          safeParseBody(event.request).then((requestBody) => {
+            if (requestBody !== undefined)
+              updateLog(event.requestId, { requestBody })
+          })
+          break
+        case "unhandled":
+          if (!shouldCaptureRequest(event.request.url)) break
+          appendLog({
+            id: event.requestId,
+            timestamp: event.timestamp,
+            method: event.request.method,
+            url: event.request.url,
+            matched: false,
+            duration: startTimes.get(event.requestId)
+              ? performance.now() - startTimes.get(event.requestId)!
+              : undefined
+          })
+          safeParseBody(event.request).then((requestBody) => {
+            if (requestBody !== undefined)
+              updateLog(event.requestId, { requestBody })
+          })
+          break
+        case "response":
+          safeParseBody(event.response).then((responseBody) => {
+            updateLog(event.requestId, {
+              status: event.response.status,
+              duration: startTimes.get(event.requestId)
+                ? performance.now() - startTimes.get(event.requestId)!
+                : undefined,
+              responseBody
+            })
+          })
+          startTimes.delete(event.requestId)
+          break
+        case "end":
+          startTimes.delete(event.requestId)
+          break
+      }
+    }
+  }, [appendLog, updateLog])
+
+  // ---- MSW event subscription ----
   useEffect(() => {
     const worker = getWorkerWithoutThrow()
     if (!worker) return
@@ -149,20 +235,25 @@ export const RequestLogProvider = ({ children }: React.PropsWithChildren) => {
       requestId: string
     }) => {
       if (!isRecordingRef.current) return
+      if (!shouldCaptureRequest(request.url)) return
 
       const startTime = startTimesRef.current.get(requestId)
 
-      // body 비동기 파싱 후 로그 추가
+      // Create entry synchronously so response:mocked can find it
+      appendLog({
+        id: requestId,
+        timestamp: Date.now(),
+        method: request.method,
+        url: request.url,
+        matched: true,
+        duration: startTime ? performance.now() - startTime : undefined
+      })
+
+      // Parse body async and patch later
       safeParseBody(request).then((requestBody) => {
-        appendLog({
-          id: requestId,
-          timestamp: Date.now(),
-          method: request.method,
-          url: request.url,
-          matched: true,
-          requestBody,
-          duration: startTime ? performance.now() - startTime : undefined
-        })
+        if (requestBody !== undefined) {
+          updateLog(requestId, { requestBody })
+        }
       })
     }
 
@@ -174,19 +265,23 @@ export const RequestLogProvider = ({ children }: React.PropsWithChildren) => {
       requestId: string
     }) => {
       if (!isRecordingRef.current) return
+      if (!shouldCaptureRequest(request.url)) return
 
       const startTime = startTimesRef.current.get(requestId)
 
+      appendLog({
+        id: requestId,
+        timestamp: Date.now(),
+        method: request.method,
+        url: request.url,
+        matched: false,
+        duration: startTime ? performance.now() - startTime : undefined
+      })
+
       safeParseBody(request).then((requestBody) => {
-        appendLog({
-          id: requestId,
-          timestamp: Date.now(),
-          method: request.method,
-          url: request.url,
-          matched: false,
-          requestBody,
-          duration: startTime ? performance.now() - startTime : undefined
-        })
+        if (requestBody !== undefined) {
+          updateLog(requestId, { requestBody })
+        }
       })
     }
 
@@ -211,12 +306,17 @@ export const RequestLogProvider = ({ children }: React.PropsWithChildren) => {
         })
       })
 
-      // 타임스탬프 정리
+      // Clean up start timestamp
       startTimesRef.current.delete(requestId)
     }
 
-    const handleRequestEnd = ({ requestId }: { request: Request; requestId: string }) => {
-      // startTimes 메모리 정리 (response:mocked에서 이미 삭제되지 않은 경우)
+    const handleRequestEnd = ({
+      requestId
+    }: {
+      request: Request
+      requestId: string
+    }) => {
+      // Clean up startTimes (in case response:mocked didn't fire)
       startTimesRef.current.delete(requestId)
     }
 
@@ -245,7 +345,7 @@ export const RequestLogProvider = ({ children }: React.PropsWithChildren) => {
     setUnreadCount(0)
   }, [])
 
-  // ---- context value 메모이제이션 ----
+  // ---- Memoized context value ----
   const value = useMemo<RequestLogContextType>(
     () => ({
       logs,

--- a/packages/msw-devtools/src/components/contexts/request-log.tsx
+++ b/packages/msw-devtools/src/components/contexts/request-log.tsx
@@ -1,0 +1,262 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react"
+
+import { Tab } from "~/constants"
+import { getWorkerWithoutThrow } from "~/lib/msw/worker"
+
+import { useTab } from "../tabs/TabBar/context"
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type RequestLogEntry = {
+  id: string
+  timestamp: number
+  method: string
+  url: string
+  status?: number
+  duration?: number
+  matched: boolean
+  requestBody?: unknown
+  responseBody?: unknown
+  mockType?: "sequential" | "prompt" | null
+}
+
+export type RequestLogContextType = {
+  logs: RequestLogEntry[]
+  isRecording: boolean
+  setIsRecording: (value: boolean) => void
+  clearLogs: () => void
+  unreadCount: number
+  resetUnreadCount: () => void
+}
+
+// ---------------------------------------------------------------------------
+// 상수
+// ---------------------------------------------------------------------------
+
+/** FIFO 최대 로그 수 */
+const MAX_LOG_SIZE = 200
+
+// Tab.Log 상수 참조
+const TAB_LOG = Tab.Log
+
+// ---------------------------------------------------------------------------
+// Context + Hook
+// ---------------------------------------------------------------------------
+
+const RequestLogContext =
+  React.createContext<RequestLogContextType | null>(null)
+
+export const useRequestLog = () => {
+  const context = React.useContext(RequestLogContext)
+  if (!context) {
+    throw new Error(
+      "[MSW Devtools] useRequestLog must be used within a RequestLogProvider"
+    )
+  }
+  return context
+}
+
+// ---------------------------------------------------------------------------
+// Helper: request body를 안전하게 파싱
+// ---------------------------------------------------------------------------
+
+async function safeParseBody(
+  source: Request | Response
+): Promise<unknown | undefined> {
+  try {
+    const cloned = source.clone()
+    const text = await cloned.text()
+    if (!text) return undefined
+    try {
+      return JSON.parse(text)
+    } catch {
+      return text
+    }
+  } catch {
+    return undefined
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Provider
+// ---------------------------------------------------------------------------
+
+export const RequestLogProvider = ({ children }: React.PropsWithChildren) => {
+  const [logs, setLogs] = useState<RequestLogEntry[]>([])
+  const [isRecording, setIsRecording] = useState(true)
+  const [unreadCount, setUnreadCount] = useState(0)
+
+  // useRef로 안정 참조 — 이벤트 핸들러 내에서 최신 값 접근
+  const isRecordingRef = useRef(isRecording)
+  isRecordingRef.current = isRecording
+
+  // 현재 탭 확인 (Log 탭이 아니면 unreadCount 증가)
+  const { tab } = useTab()
+  const tabRef = useRef(tab)
+  tabRef.current = tab
+
+  // request:start 시각 기록용 Map
+  const startTimesRef = useRef(new Map<string, number>())
+
+  // ---- FIFO append 헬퍼 ----
+  const appendLog = useCallback((entry: RequestLogEntry) => {
+    setLogs((prev) => {
+      const next = [...prev, entry]
+      return next.length > MAX_LOG_SIZE ? next.slice(-MAX_LOG_SIZE) : next
+    })
+    // 현재 탭이 Log가 아니면 unread 증가
+    if (tabRef.current !== TAB_LOG) {
+      setUnreadCount((c) => c + 1)
+    }
+  }, [])
+
+  // ---- 로그 항목 업데이트 헬퍼 (response:mocked / response:bypass) ----
+  const updateLog = useCallback(
+    (
+      requestId: string,
+      patch: Partial<Pick<RequestLogEntry, "status" | "duration" | "responseBody">>
+    ) => {
+      setLogs((prev) =>
+        prev.map((entry) =>
+          entry.id === requestId ? { ...entry, ...patch } : entry
+        )
+      )
+    },
+    []
+  )
+
+  // ---- MSW 이벤트 구독 ----
+  useEffect(() => {
+    const worker = getWorkerWithoutThrow()
+    if (!worker) return
+
+    const handleRequestStart = ({
+      requestId
+    }: {
+      request: Request
+      requestId: string
+    }) => {
+      startTimesRef.current.set(requestId, performance.now())
+    }
+
+    const handleRequestMatch = ({
+      request,
+      requestId
+    }: {
+      request: Request
+      requestId: string
+    }) => {
+      if (!isRecordingRef.current) return
+
+      const startTime = startTimesRef.current.get(requestId)
+
+      // body 비동기 파싱 후 로그 추가
+      safeParseBody(request).then((requestBody) => {
+        appendLog({
+          id: requestId,
+          timestamp: Date.now(),
+          method: request.method,
+          url: request.url,
+          matched: true,
+          requestBody,
+          duration: startTime ? performance.now() - startTime : undefined
+        })
+      })
+    }
+
+    const handleRequestUnhandled = ({
+      request,
+      requestId
+    }: {
+      request: Request
+      requestId: string
+    }) => {
+      if (!isRecordingRef.current) return
+
+      const startTime = startTimesRef.current.get(requestId)
+
+      safeParseBody(request).then((requestBody) => {
+        appendLog({
+          id: requestId,
+          timestamp: Date.now(),
+          method: request.method,
+          url: request.url,
+          matched: false,
+          requestBody,
+          duration: startTime ? performance.now() - startTime : undefined
+        })
+      })
+    }
+
+    const handleResponseMocked = ({
+      response,
+      requestId
+    }: {
+      response: Response
+      request: Request
+      requestId: string
+    }) => {
+      if (!isRecordingRef.current) return
+
+      const startTime = startTimesRef.current.get(requestId)
+      const duration = startTime ? performance.now() - startTime : undefined
+
+      safeParseBody(response).then((responseBody) => {
+        updateLog(requestId, {
+          status: response.status,
+          duration,
+          responseBody
+        })
+      })
+
+      // 타임스탬프 정리
+      startTimesRef.current.delete(requestId)
+    }
+
+    const handleRequestEnd = ({ requestId }: { request: Request; requestId: string }) => {
+      // startTimes 메모리 정리 (response:mocked에서 이미 삭제되지 않은 경우)
+      startTimesRef.current.delete(requestId)
+    }
+
+    worker.events.on("request:start", handleRequestStart)
+    worker.events.on("request:match", handleRequestMatch)
+    worker.events.on("request:unhandled", handleRequestUnhandled)
+    worker.events.on("response:mocked", handleResponseMocked)
+    worker.events.on("request:end", handleRequestEnd)
+
+    return () => {
+      worker.events.removeListener("request:start", handleRequestStart)
+      worker.events.removeListener("request:match", handleRequestMatch)
+      worker.events.removeListener("request:unhandled", handleRequestUnhandled)
+      worker.events.removeListener("response:mocked", handleResponseMocked)
+      worker.events.removeListener("request:end", handleRequestEnd)
+    }
+  }, [appendLog, updateLog])
+
+  // ---- clearLogs / resetUnreadCount ----
+  const clearLogs = useCallback(() => {
+    setLogs([])
+    setUnreadCount(0)
+  }, [])
+
+  const resetUnreadCount = useCallback(() => {
+    setUnreadCount(0)
+  }, [])
+
+  // ---- context value 메모이제이션 ----
+  const value = useMemo<RequestLogContextType>(
+    () => ({
+      logs,
+      isRecording,
+      setIsRecording,
+      clearLogs,
+      unreadCount,
+      resetUnreadCount
+    }),
+    [logs, isRecording, clearLogs, unreadCount, resetUnreadCount]
+  )
+
+  return <RequestLogContext value={value}>{children}</RequestLogContext>
+}

--- a/packages/msw-devtools/src/components/tabs/TabBar/TabBar.tsx
+++ b/packages/msw-devtools/src/components/tabs/TabBar/TabBar.tsx
@@ -34,6 +34,7 @@ export const TabBar = ({ children }: React.PropsWithChildren) => {
     <div className='flex h-10 items-center gap-0.5 border-b border-slate-200 px-2'>
       <TabButton tab={Tab.AddMock} />
       <TabButton tab={Tab.MockList} />
+      <TabButton tab={Tab.Log} />
       <TabButton tab={Tab.Settings} />
       <div className='mx-auto'></div>
       {children}

--- a/packages/msw-devtools/src/components/tabs/TabBar/TabBar.tsx
+++ b/packages/msw-devtools/src/components/tabs/TabBar/TabBar.tsx
@@ -1,11 +1,12 @@
 import { clsx } from "clsx"
 import { useTranslation } from "react-i18next"
 
+import { useRequestLog } from "~/components/contexts/request-log"
 import { Tab } from "~/constants"
 
 import { useTab } from "./context"
 
-const TabButton = ({ tab }: { tab: Tab }) => {
+const TabButton = ({ tab, badge }: { tab: Tab; badge?: number }) => {
   const { tab: currentTab, setTab } = useTab()
   const { t } = useTranslation()
 
@@ -22,6 +23,11 @@ const TabButton = ({ tab }: { tab: Tab }) => {
       onClick={() => setTab(tab)}
     >
       {t(tab)}
+      {!!badge && badge > 0 && (
+        <span className='ml-0.5 inline-flex min-w-[1rem] items-center justify-center rounded-full bg-red-500 px-1 py-0.5 text-[0.5rem] font-bold leading-none text-white'>
+          {badge > 99 ? "99+" : badge}
+        </span>
+      )}
       {isActive && (
         <span className='absolute bottom-0 left-1 right-1 h-[2px] rounded-full bg-slate-700' />
       )}
@@ -30,11 +36,13 @@ const TabButton = ({ tab }: { tab: Tab }) => {
 }
 
 export const TabBar = ({ children }: React.PropsWithChildren) => {
+  const { unreadCount } = useRequestLog()
+
   return (
     <div className='flex h-10 items-center gap-0.5 border-b border-slate-200 px-2'>
       <TabButton tab={Tab.AddMock} />
       <TabButton tab={Tab.MockList} />
-      <TabButton tab={Tab.Log} />
+      <TabButton tab={Tab.Log} badge={unreadCount} />
       <TabButton tab={Tab.Settings} />
       <div className='mx-auto'></div>
       {children}

--- a/packages/msw-devtools/src/components/tabs/TabBody/LogTab/LogControls.tsx
+++ b/packages/msw-devtools/src/components/tabs/TabBody/LogTab/LogControls.tsx
@@ -23,7 +23,7 @@ export const LogControls = ({
 
   return (
     <div className='flex items-center gap-3 border-b border-slate-200 px-3 py-2'>
-      {/* Recording 토글 */}
+      {/* Recording toggle */}
       <label className='flex items-center gap-1.5'>
         <span
           className={clsx(
@@ -31,15 +31,14 @@ export const LogControls = ({
             isRecording ? "text-red-500" : "text-slate-400"
           )}
         >
-          {isRecording ? `● ${t("tabs.log.recording")}` : `⏸ ${t("tabs.log.paused")}`}
+          {isRecording
+            ? `● ${t("tabs.log.recording")}`
+            : `⏸ ${t("tabs.log.paused")}`}
         </span>
-        <Toggle
-          checked={isRecording}
-          onChange={onToggleRecording}
-        />
+        <Toggle checked={isRecording} onChange={onToggleRecording} />
       </label>
 
-      {/* Filter 버튼 */}
+      {/* Filter buttons */}
       <div className='flex items-center gap-1'>
         {(["all", "matched", "unmatched"] as const).map((f) => (
           <button
@@ -58,7 +57,7 @@ export const LogControls = ({
         ))}
       </div>
 
-      {/* Clear 버튼 */}
+      {/* Clear button */}
       <button
         type='button'
         title={t("tabs.log.clearButton.title")}

--- a/packages/msw-devtools/src/components/tabs/TabBody/LogTab/LogControls.tsx
+++ b/packages/msw-devtools/src/components/tabs/TabBody/LogTab/LogControls.tsx
@@ -1,0 +1,72 @@
+import { clsx } from "clsx"
+import { useTranslation } from "react-i18next"
+import { FaRegTrashCan } from "react-icons/fa6"
+
+import { Toggle } from "~/components/Toggle"
+
+export type LogFilter = "all" | "matched" | "unmatched"
+
+export const LogControls = ({
+  isRecording,
+  onToggleRecording,
+  onClear,
+  filter,
+  onFilterChange
+}: {
+  isRecording: boolean
+  onToggleRecording: () => void
+  onClear: () => void
+  filter: LogFilter
+  onFilterChange: (filter: LogFilter) => void
+}) => {
+  const { t } = useTranslation()
+
+  return (
+    <div className='flex items-center gap-3 border-b border-slate-200 px-3 py-2'>
+      {/* Recording 토글 */}
+      <label className='flex items-center gap-1.5'>
+        <span
+          className={clsx(
+            "text-[0.65rem] font-semibold",
+            isRecording ? "text-red-500" : "text-slate-400"
+          )}
+        >
+          {isRecording ? `● ${t("tabs.log.recording")}` : `⏸ ${t("tabs.log.paused")}`}
+        </span>
+        <Toggle
+          checked={isRecording}
+          onChange={onToggleRecording}
+        />
+      </label>
+
+      {/* Filter 버튼 */}
+      <div className='flex items-center gap-1'>
+        {(["all", "matched", "unmatched"] as const).map((f) => (
+          <button
+            key={f}
+            type='button'
+            className={clsx(
+              "rounded px-2 py-0.5 text-[0.65rem] transition-colors",
+              filter === f
+                ? "bg-slate-700 font-semibold text-white"
+                : "text-slate-400 hover:bg-slate-100 hover:text-slate-600"
+            )}
+            onClick={() => onFilterChange(f)}
+          >
+            {t(`tabs.log.filter.${f}`)}
+          </button>
+        ))}
+      </div>
+
+      {/* Clear 버튼 */}
+      <button
+        type='button'
+        title={t("tabs.log.clearButton.title")}
+        className='ml-auto rounded p-1.5 text-slate-400 transition-colors hover:bg-slate-100 hover:text-slate-600'
+        onClick={onClear}
+      >
+        <FaRegTrashCan size={12} />
+      </button>
+    </div>
+  )
+}

--- a/packages/msw-devtools/src/components/tabs/TabBody/LogTab/LogDetail.tsx
+++ b/packages/msw-devtools/src/components/tabs/TabBody/LogTab/LogDetail.tsx
@@ -62,7 +62,7 @@ export const LogDetail = ({ entry }: { entry: RequestLogEntry }) => {
         </div>
       )}
 
-      {/* Unmatched 요청: Add Mock 버튼 */}
+      {/* Unmatched request: Add Mock button */}
       {!entry.matched && (
         <button
           type='button'
@@ -74,10 +74,10 @@ export const LogDetail = ({ entry }: { entry: RequestLogEntry }) => {
         </button>
       )}
 
-      {/* body가 전부 없는 경우 */}
+      {/* No body data available */}
       {!hasRequestBody && !hasResponseBody && entry.matched && (
         <p className='text-[0.65rem] text-slate-400'>
-          No body data available.
+          {t("tabs.log.noBodyData")}
         </p>
       )}
     </div>

--- a/packages/msw-devtools/src/components/tabs/TabBody/LogTab/LogDetail.tsx
+++ b/packages/msw-devtools/src/components/tabs/TabBody/LogTab/LogDetail.tsx
@@ -1,0 +1,85 @@
+import { BasicSetupOptions } from "@uiw/react-codemirror"
+import { useTranslation } from "react-i18next"
+import { FaPlus } from "react-icons/fa6"
+
+import { CodeEditor } from "~/components/CodeEditor"
+import type { RequestLogEntry } from "~/components/contexts/request-log"
+import { useTab } from "~/components/tabs/TabBar/context"
+import { Tab } from "~/constants"
+
+const CODE_EDITOR_BASIC_SETUP_OPTIONS: BasicSetupOptions = {
+  highlightActiveLine: false
+}
+
+const formatBody = (body: unknown): string => {
+  if (body === undefined || body === null) return ""
+  if (typeof body === "string") return body
+  try {
+    return JSON.stringify(body, null, 2)
+  } catch {
+    return String(body)
+  }
+}
+
+export const LogDetail = ({ entry }: { entry: RequestLogEntry }) => {
+  const { t } = useTranslation()
+  const { setTab } = useTab()
+
+  const hasRequestBody =
+    entry.requestBody !== undefined && entry.requestBody !== null
+  const hasResponseBody =
+    entry.responseBody !== undefined && entry.responseBody !== null
+
+  return (
+    <div className='space-y-3 px-2 pb-3 pt-2'>
+      {/* Request Body */}
+      {hasRequestBody && (
+        <div>
+          <p className='mb-1 text-[0.65rem] font-semibold text-slate-500'>
+            {t("tabs.log.requestBody")}
+          </p>
+          <CodeEditor
+            value={formatBody(entry.requestBody)}
+            basicSetup={CODE_EDITOR_BASIC_SETUP_OPTIONS}
+            minHeight='auto'
+            readOnly
+          />
+        </div>
+      )}
+
+      {/* Response Body */}
+      {hasResponseBody && (
+        <div>
+          <p className='mb-1 text-[0.65rem] font-semibold text-slate-500'>
+            {t("tabs.log.responseBody")}
+          </p>
+          <CodeEditor
+            value={formatBody(entry.responseBody)}
+            basicSetup={CODE_EDITOR_BASIC_SETUP_OPTIONS}
+            minHeight='auto'
+            readOnly
+          />
+        </div>
+      )}
+
+      {/* Unmatched 요청: Add Mock 버튼 */}
+      {!entry.matched && (
+        <button
+          type='button'
+          className='flex items-center gap-1.5 rounded bg-slate-700 px-3 py-1.5 text-[0.65rem] font-semibold text-white transition-colors hover:bg-slate-800'
+          onClick={() => setTab(Tab.AddMock)}
+        >
+          <FaPlus size={10} />
+          {t("tabs.log.addMockButton")}
+        </button>
+      )}
+
+      {/* body가 전부 없는 경우 */}
+      {!hasRequestBody && !hasResponseBody && entry.matched && (
+        <p className='text-[0.65rem] text-slate-400'>
+          No body data available.
+        </p>
+      )}
+    </div>
+  )
+}

--- a/packages/msw-devtools/src/components/tabs/TabBody/LogTab/LogEntry.tsx
+++ b/packages/msw-devtools/src/components/tabs/TabBody/LogTab/LogEntry.tsx
@@ -1,0 +1,116 @@
+import { clsx } from "clsx"
+import { type MethodOption } from "core"
+import { useTranslation } from "react-i18next"
+import { FaBolt, FaChevronRight, FaTriangleExclamation } from "react-icons/fa6"
+
+import type { RequestLogEntry } from "~/components/contexts/request-log"
+import { MethodPill } from "~/components/MethodPill"
+import { UrlText } from "~/components/UrlText"
+import { useBoolean } from "~/hooks/useBoolean"
+
+import { LogDetail } from "./LogDetail"
+
+/** timestamp를 HH:MM:SS 형식으로 변환 */
+const formatTime = (timestamp: number): string => {
+  const date = new Date(timestamp)
+  return [date.getHours(), date.getMinutes(), date.getSeconds()]
+    .map((n) => String(n).padStart(2, "0"))
+    .join(":")
+}
+
+/** status에 따른 색상 */
+const getStatusColor = (status?: number): string => {
+  if (!status) return "text-slate-400"
+  if (status >= 200 && status < 300) return "text-green-700"
+  if (status >= 300 && status < 400) return "text-yellow-700"
+  if (status >= 400) return "text-red-700"
+  return "text-slate-600"
+}
+
+const getStatusBg = (status?: number): string => {
+  if (!status) return ""
+  if (status >= 200 && status < 300) return "bg-green-50"
+  if (status >= 300 && status < 400) return "bg-yellow-50"
+  if (status >= 400) return "bg-red-50"
+  return ""
+}
+
+export const LogEntry = ({ entry }: { entry: RequestLogEntry }) => {
+  const [isOpened, , , toggle] = useBoolean(false)
+  const { t } = useTranslation()
+
+  return (
+    <div
+      className={clsx(
+        "rounded-md border border-slate-200 bg-white text-xs",
+        !entry.matched && "border-l-2 border-l-yellow-400"
+      )}
+    >
+      {/* 행 헤더 (클릭 가능) */}
+      <button
+        type='button'
+        className='flex w-full items-center gap-1.5 px-2 py-1.5 text-left'
+        onClick={toggle}
+      >
+        {/* 아코디언 화살표 */}
+        <FaChevronRight
+          size={8}
+          className={clsx(
+            "shrink-0 transform-gpu text-slate-400 transition-transform duration-200",
+            isOpened && "rotate-90"
+          )}
+        />
+
+        {/* 시간 */}
+        <span className='shrink-0 font-mono text-[0.6rem] text-slate-400'>
+          {formatTime(entry.timestamp)}
+        </span>
+
+        {/* Method */}
+        <MethodPill method={entry.method as MethodOption} />
+
+        {/* Status */}
+        {entry.status != null && (
+          <span
+            className={clsx(
+              "shrink-0 rounded px-1.5 py-0.5 font-mono text-[0.65rem] font-semibold",
+              getStatusColor(entry.status),
+              getStatusBg(entry.status)
+            )}
+          >
+            {entry.status}
+          </span>
+        )}
+
+        {/* URL */}
+        <UrlText className='flex-1'>{entry.url}</UrlText>
+
+        {/* 응답시간 */}
+        {entry.duration != null && (
+          <span className='shrink-0 font-mono text-[0.6rem] text-slate-400'>
+            {t("tabs.log.duration", { ms: Math.round(entry.duration) })}
+          </span>
+        )}
+
+        {/* Matched/Unmatched 아이콘 */}
+        {entry.matched ? (
+          <FaBolt size={10} className='shrink-0 text-green-500' />
+        ) : (
+          <FaTriangleExclamation size={10} className='shrink-0 text-yellow-500' />
+        )}
+      </button>
+
+      {/* 아코디언 상세 */}
+      <div
+        className={clsx(
+          "grid overflow-hidden transition-[grid-template-rows] duration-300",
+          isOpened ? "grid-rows-[1fr]" : "grid-rows-[0fr]"
+        )}
+      >
+        <div className='overflow-hidden'>
+          {isOpened && <LogDetail entry={entry} />}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/packages/msw-devtools/src/components/tabs/TabBody/LogTab/LogEntry.tsx
+++ b/packages/msw-devtools/src/components/tabs/TabBody/LogTab/LogEntry.tsx
@@ -10,7 +10,7 @@ import { useBoolean } from "~/hooks/useBoolean"
 
 import { LogDetail } from "./LogDetail"
 
-/** timestamp를 HH:MM:SS 형식으로 변환 */
+/** Format timestamp as HH:MM:SS */
 const formatTime = (timestamp: number): string => {
   const date = new Date(timestamp)
   return [date.getHours(), date.getMinutes(), date.getSeconds()]
@@ -18,7 +18,7 @@ const formatTime = (timestamp: number): string => {
     .join(":")
 }
 
-/** status에 따른 색상 */
+/** Status code text color */
 const getStatusColor = (status?: number): string => {
   if (!status) return "text-slate-400"
   if (status >= 200 && status < 300) return "text-green-700"
@@ -46,13 +46,13 @@ export const LogEntry = ({ entry }: { entry: RequestLogEntry }) => {
         !entry.matched && "border-l-2 border-l-yellow-400"
       )}
     >
-      {/* 행 헤더 (클릭 가능) */}
+      {/* Row header (clickable) */}
       <button
         type='button'
         className='flex w-full items-center gap-1.5 px-2 py-1.5 text-left'
         onClick={toggle}
       >
-        {/* 아코디언 화살표 */}
+        {/* Accordion arrow */}
         <FaChevronRight
           size={8}
           className={clsx(
@@ -61,7 +61,7 @@ export const LogEntry = ({ entry }: { entry: RequestLogEntry }) => {
           )}
         />
 
-        {/* 시간 */}
+        {/* Time */}
         <span className='shrink-0 font-mono text-[0.6rem] text-slate-400'>
           {formatTime(entry.timestamp)}
         </span>
@@ -85,22 +85,25 @@ export const LogEntry = ({ entry }: { entry: RequestLogEntry }) => {
         {/* URL */}
         <UrlText className='flex-1'>{entry.url}</UrlText>
 
-        {/* 응답시간 */}
+        {/* Duration */}
         {entry.duration != null && (
           <span className='shrink-0 font-mono text-[0.6rem] text-slate-400'>
             {t("tabs.log.duration", { ms: Math.round(entry.duration) })}
           </span>
         )}
 
-        {/* Matched/Unmatched 아이콘 */}
+        {/* Matched/Unmatched icon */}
         {entry.matched ? (
           <FaBolt size={10} className='shrink-0 text-green-500' />
         ) : (
-          <FaTriangleExclamation size={10} className='shrink-0 text-yellow-500' />
+          <FaTriangleExclamation
+            size={10}
+            className='shrink-0 text-yellow-500'
+          />
         )}
       </button>
 
-      {/* 아코디언 상세 */}
+      {/* Accordion detail */}
       <div
         className={clsx(
           "grid overflow-hidden transition-[grid-template-rows] duration-300",

--- a/packages/msw-devtools/src/components/tabs/TabBody/LogTab/LogTab.tsx
+++ b/packages/msw-devtools/src/components/tabs/TabBody/LogTab/LogTab.tsx
@@ -14,19 +14,19 @@ export const LogTab = () => {
   const [filter, setFilter] = useState<LogFilter>("all")
   const listRef = useRef<HTMLDivElement>(null)
 
-  // Log 탭 진입 시 unreadCount 리셋
+  // Reset unreadCount when entering Log tab
   useEffect(() => {
     resetUnreadCount()
   }, [resetUnreadCount])
 
-  // 필터링된 로그
+  // Filtered logs
   const filteredLogs = useMemo(() => {
     if (filter === "all") return logs
     if (filter === "matched") return logs.filter((l) => l.matched)
     return logs.filter((l) => !l.matched)
   }, [logs, filter])
 
-  // 새 로그 추가 시 자동 스크롤
+  // Auto-scroll on new log entries
   const prevLengthRef = useRef(filteredLogs.length)
   useEffect(() => {
     if (filteredLogs.length > prevLengthRef.current) {

--- a/packages/msw-devtools/src/components/tabs/TabBody/LogTab/LogTab.tsx
+++ b/packages/msw-devtools/src/components/tabs/TabBody/LogTab/LogTab.tsx
@@ -1,0 +1,11 @@
+import { useTranslation } from "react-i18next"
+
+export const LogTab = () => {
+  const { t } = useTranslation()
+
+  return (
+    <div className='flex h-full items-center justify-center text-sm text-slate-400'>
+      {t("tabs.log.noLogs")}
+    </div>
+  )
+}

--- a/packages/msw-devtools/src/components/tabs/TabBody/LogTab/LogTab.tsx
+++ b/packages/msw-devtools/src/components/tabs/TabBody/LogTab/LogTab.tsx
@@ -1,11 +1,68 @@
+import { useEffect, useMemo, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 
+import { useRequestLog } from "~/components/contexts/request-log"
+
+import { type LogFilter, LogControls } from "./LogControls"
+import { LogEntry } from "./LogEntry"
+
 export const LogTab = () => {
+  const { logs, isRecording, setIsRecording, clearLogs, resetUnreadCount } =
+    useRequestLog()
   const { t } = useTranslation()
 
+  const [filter, setFilter] = useState<LogFilter>("all")
+  const listRef = useRef<HTMLDivElement>(null)
+
+  // Log 탭 진입 시 unreadCount 리셋
+  useEffect(() => {
+    resetUnreadCount()
+  }, [resetUnreadCount])
+
+  // 필터링된 로그
+  const filteredLogs = useMemo(() => {
+    if (filter === "all") return logs
+    if (filter === "matched") return logs.filter((l) => l.matched)
+    return logs.filter((l) => !l.matched)
+  }, [logs, filter])
+
+  // 새 로그 추가 시 자동 스크롤
+  const prevLengthRef = useRef(filteredLogs.length)
+  useEffect(() => {
+    if (filteredLogs.length > prevLengthRef.current) {
+      listRef.current?.scrollTo({
+        top: listRef.current.scrollHeight,
+        behavior: "smooth"
+      })
+    }
+    prevLengthRef.current = filteredLogs.length
+  }, [filteredLogs.length])
+
   return (
-    <div className='flex h-full items-center justify-center text-sm text-slate-400'>
-      {t("tabs.log.noLogs")}
+    <div className='flex h-full flex-col'>
+      <LogControls
+        isRecording={isRecording}
+        onToggleRecording={() => setIsRecording(!isRecording)}
+        onClear={clearLogs}
+        filter={filter}
+        onFilterChange={setFilter}
+      />
+
+      {filteredLogs.length === 0 ? (
+        <div className='flex flex-1 items-center justify-center text-sm text-slate-400'>
+          {t("tabs.log.noLogs")}
+        </div>
+      ) : (
+        <div ref={listRef} className='flex-1 overflow-auto p-3'>
+          <ul className='w-full space-y-1.5'>
+            {filteredLogs.map((entry) => (
+              <li key={entry.id}>
+                <LogEntry entry={entry} />
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
     </div>
   )
 }

--- a/packages/msw-devtools/src/components/tabs/TabBody/LogTab/LogTab.tsx
+++ b/packages/msw-devtools/src/components/tabs/TabBody/LogTab/LogTab.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from "react-i18next"
 
 import { useRequestLog } from "~/components/contexts/request-log"
 
-import { type LogFilter, LogControls } from "./LogControls"
+import { LogControls, type LogFilter } from "./LogControls"
 import { LogEntry } from "./LogEntry"
 
 export const LogTab = () => {

--- a/packages/msw-devtools/src/components/tabs/TabBody/LogTab/index.ts
+++ b/packages/msw-devtools/src/components/tabs/TabBody/LogTab/index.ts
@@ -1,0 +1,1 @@
+export * from "./LogTab"

--- a/packages/msw-devtools/src/components/tabs/TabBody/TabBody.tsx
+++ b/packages/msw-devtools/src/components/tabs/TabBody/TabBody.tsx
@@ -7,6 +7,7 @@ import { useTab } from "~/components/tabs/TabBar/context"
 import { Tab } from "~/constants"
 
 import { AddMockTab } from "./AddMockTab"
+import { LogTab } from "./LogTab"
 import { MockListTab } from "./MockListTab"
 import { SettingsTab } from "./SettingsTab"
 
@@ -22,6 +23,7 @@ export const TabBody = () => {
               <EditStateProvider>
                 {tab === Tab.AddMock && <AddMockTab />}
                 {tab === Tab.MockList && <MockListTab />}
+                {tab === Tab.Log && <LogTab />}
                 {tab === Tab.Settings && <SettingsTab />}
               </EditStateProvider>
             </MockListProvider>

--- a/packages/msw-devtools/src/constants.ts
+++ b/packages/msw-devtools/src/constants.ts
@@ -50,6 +50,7 @@ export const StorageKey = {
 export const Tab = {
   AddMock: "tab.addMock",
   MockList: "tab.mockList",
+  Log: "tab.log",
   Settings: "tab.settings"
 } as const
 

--- a/packages/msw-devtools/src/lib/msw/worker.ts
+++ b/packages/msw-devtools/src/lib/msw/worker.ts
@@ -48,6 +48,7 @@ let _earlyBuffer: EarlyEvent[] = []
 let _cleanupEarlyCapture: (() => void) | null = null
 
 function startEarlyCapture(worker: Worker) {
+  if (!worker?.events) return
   _earlyBuffer = []
 
   const onStart = ({ requestId }: { request: Request; requestId: string }) => {

--- a/packages/msw-devtools/src/lib/msw/worker.ts
+++ b/packages/msw-devtools/src/lib/msw/worker.ts
@@ -19,4 +19,111 @@ export const getWorkerWithoutThrow = () => {
 
 export const setWorker = (worker: Worker) => {
   _worker = worker
+  startEarlyCapture(worker)
+}
+
+// ---------------------------------------------------------------------------
+// Early capture: buffer MSW events from worker start so that requests
+// occurring before RequestLogProvider mounts are not lost.
+// ---------------------------------------------------------------------------
+
+export type EarlyEvent =
+  | { type: "start"; requestId: string; timestamp: number }
+  | { type: "match"; requestId: string; request: Request; timestamp: number }
+  | {
+      type: "unhandled"
+      requestId: string
+      request: Request
+      timestamp: number
+    }
+  | {
+      type: "response"
+      requestId: string
+      response: Response
+      timestamp: number
+    }
+  | { type: "end"; requestId: string }
+
+let _earlyBuffer: EarlyEvent[] = []
+let _cleanupEarlyCapture: (() => void) | null = null
+
+function startEarlyCapture(worker: Worker) {
+  _earlyBuffer = []
+
+  const onStart = ({ requestId }: { request: Request; requestId: string }) => {
+    _earlyBuffer.push({
+      type: "start",
+      requestId,
+      timestamp: performance.now()
+    })
+  }
+  const onMatch = ({
+    request,
+    requestId
+  }: {
+    request: Request
+    requestId: string
+  }) => {
+    _earlyBuffer.push({
+      type: "match",
+      requestId,
+      request: request.clone(),
+      timestamp: Date.now()
+    })
+  }
+  const onUnhandled = ({
+    request,
+    requestId
+  }: {
+    request: Request
+    requestId: string
+  }) => {
+    _earlyBuffer.push({
+      type: "unhandled",
+      requestId,
+      request: request.clone(),
+      timestamp: Date.now()
+    })
+  }
+  const onResponse = ({
+    response,
+    requestId
+  }: {
+    response: Response
+    request: Request
+    requestId: string
+  }) => {
+    _earlyBuffer.push({
+      type: "response",
+      requestId,
+      response: response.clone(),
+      timestamp: performance.now()
+    })
+  }
+  const onEnd = ({ requestId }: { request: Request; requestId: string }) => {
+    _earlyBuffer.push({ type: "end", requestId })
+  }
+
+  worker.events.on("request:start", onStart)
+  worker.events.on("request:match", onMatch)
+  worker.events.on("request:unhandled", onUnhandled)
+  worker.events.on("response:mocked", onResponse)
+  worker.events.on("request:end", onEnd)
+
+  _cleanupEarlyCapture = () => {
+    worker.events.removeListener("request:start", onStart)
+    worker.events.removeListener("request:match", onMatch)
+    worker.events.removeListener("request:unhandled", onUnhandled)
+    worker.events.removeListener("response:mocked", onResponse)
+    worker.events.removeListener("request:end", onEnd)
+  }
+}
+
+/** Called when RequestLogProvider mounts — returns buffered events and removes early listeners */
+export function drainEarlyBuffer(): EarlyEvent[] {
+  _cleanupEarlyCapture?.()
+  _cleanupEarlyCapture = null
+  const buffer = _earlyBuffer
+  _earlyBuffer = []
+  return buffer
 }

--- a/packages/msw-devtools/src/locales/en/common.json
+++ b/packages/msw-devtools/src/locales/en/common.json
@@ -85,7 +85,8 @@
       "noLogs": "No requests captured yet",
       "requestBody": "Request Body",
       "responseBody": "Response Body",
-      "duration": "{{ms}}ms"
+      "duration": "{{ms}}ms",
+      "noBodyData": "No body data available."
     },
     "settings": {
       "defaultResponseDelay": {

--- a/packages/msw-devtools/src/locales/en/common.json
+++ b/packages/msw-devtools/src/locales/en/common.json
@@ -20,6 +20,7 @@
   "tab": {
     "addMock": "Add Mock",
     "mockList": "Mock List",
+    "log": "Log",
     "settings": "Settings"
   },
   "tabs": {
@@ -68,6 +69,23 @@
       "toggleSidebarButton": {
         "title": "Toggle Sidebar"
       }
+    },
+    "log": {
+      "recording": "Recording",
+      "paused": "Paused",
+      "clearButton": {
+        "title": "Clear Logs"
+      },
+      "filter": {
+        "all": "All",
+        "matched": "Matched",
+        "unmatched": "Unmatched"
+      },
+      "addMockButton": "Add Mock for this URL",
+      "noLogs": "No requests captured yet",
+      "requestBody": "Request Body",
+      "responseBody": "Response Body",
+      "duration": "{{ms}}ms"
     },
     "settings": {
       "defaultResponseDelay": {

--- a/packages/msw-devtools/src/locales/ko/common.json
+++ b/packages/msw-devtools/src/locales/ko/common.json
@@ -85,7 +85,8 @@
       "noLogs": "아직 캡처된 요청이 없습니다",
       "requestBody": "요청 본문",
       "responseBody": "응답 본문",
-      "duration": "{{ms}}ms"
+      "duration": "{{ms}}ms",
+      "noBodyData": "본문 데이터가 없습니다."
     },
     "settings": {
       "defaultResponseDelay": {

--- a/packages/msw-devtools/src/locales/ko/common.json
+++ b/packages/msw-devtools/src/locales/ko/common.json
@@ -20,6 +20,7 @@
   "tab": {
     "addMock": "Mock 추가하기",
     "mockList": "Mock 목록",
+    "log": "로그",
     "settings": "설정"
   },
   "tabs": {
@@ -68,6 +69,23 @@
       "toggleSidebarButton": {
         "title": "사이드 바 토글"
       }
+    },
+    "log": {
+      "recording": "기록 중",
+      "paused": "일시 정지",
+      "clearButton": {
+        "title": "로그 전체 삭제"
+      },
+      "filter": {
+        "all": "전체",
+        "matched": "매치됨",
+        "unmatched": "미매치"
+      },
+      "addMockButton": "이 URL로 Mock 추가",
+      "noLogs": "아직 캡처된 요청이 없습니다",
+      "requestBody": "요청 본문",
+      "responseBody": "응답 본문",
+      "duration": "{{ms}}ms"
     },
     "settings": {
       "defaultResponseDelay": {


### PR DESCRIPTION
## Summary
Add a 4th **Log** tab to MSW Devtools for real-time request/response monitoring.

### Features
- Real-time logging of matched/unmatched MSW requests
- Expandable accordion for request/response body inspection
- "Add Mock for this URL" shortcut on unmatched requests
- Recording toggle, clear, filter (All/Matched/Unmatched)
- Unread badge, early capture buffer, static asset filtering
- 200 entry FIFO, memory only, full i18n (EN/KO)

### Changeset
`@custardcream/msw-devtools` minor

## Test plan
- [x] `pnpm build` / `pnpm type-check` / `pnpm lint` / `pnpm test` (139 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)